### PR TITLE
Fix(scripts): Transition npm scripts to shell executables & commands

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -2,6 +2,6 @@ FROM node:16.14.2
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 RUN npm install
-RUN npm run build
+RUN ["./node_modules/.bin/webpack", "--config", "./webpack.config.js"]
 EXPOSE 3000
 ENTRYPOINT [ "node", "--experimental-specifier-resolution=node", "./server/server.js" ]

--- a/demo/dev.sh
+++ b/demo/dev.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+docker-compose -f ./docker-compose-dev-hot.yml up

--- a/demo/docker-compose-dev-hot.yml
+++ b/demo/docker-compose-dev-hot.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - .:/usr/src/app
       - node_modules:/usr/src/app/node_modules
-    command: npm run dev:hot
+    command: ["./node_modules/.bin/concurrently", "\"NODE_ENV=development ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --open --hot\"", "\"NODE_ENV=development ./node_modules/nodemon/bin/nodemon.js --verbose --watch server --experimental-specifier-resolution=node server/server.js\""]
   postgres-db:
     image: hacheql/hql-postgres
     container_name: hql-database

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,10 +5,6 @@
   "description": "A minimal client/server to interact with a GraphQL API",
   "main": "server/server.js",
   "scripts": {
-    "build": "webpack --config ./webpack.config.js",
-    "dev:hot": "concurrently \"NODE_ENV=development webpack-dev-server --open --hot\" \"NODE_ENV=development nodemon --watch server --watch ../library --experimental-specifier-resolution=node server/server.js\"",
-    "docker-dev:hot": "docker-compose -f ./docker-compose-dev-hot.yml up",
-    "start": "node --experimental-specifier-resolution=node server/server.js;"
   },
   "author": "",
   "license": "MIT",

--- a/demo/server/server.js
+++ b/demo/server/server.js
@@ -3,7 +3,6 @@ import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import process from 'process';
 import { graphqlHTTP } from 'express-graphql';
-import util from 'util';
 import schema from './graphql/types';
 // import { v4 as uuid } from 'uuid';
 import { expressHacheQL,  httpCache } from 'hacheql/server';

--- a/demo/server/server.js
+++ b/demo/server/server.js
@@ -45,13 +45,10 @@ app.use((err, req, res, next) => {
   return res.status(errorObj.status).json(errorObj.message);
 });
 
-const server = app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
 
-const closeServer = util.promisify(server.close.bind(server));
-
-async function shutdown() {
+function shutdown() {
   try {
-    await closeServer();
     console.log('Successfully shutting down.');
     process.exit(0);
   } catch (e) {


### PR DESCRIPTION
- Fix: no longer rely on npm process management within docker env
- Fix: prevent SIGTERM/INT handling issues by transitioning from npm scripts to pure shell commands
- chore: remove all npm scripts from package json and replace them with an executable (just type ./dev to start up the live-reloading dev server)
- Feat: add robust error handling of both SIGTERM and SIGINT at server level after encountering several related bugs in this area
