### PR TITLE
Update test files

### DIFF
--- a/library/tests/HTTPStatusCodes.js
+++ b/library/tests/HTTPStatusCodes.js
@@ -1,3 +1,5 @@
-export default {
-  hashNotFound: 303,
-};
+const HASH_NOT_FOUND = 303;
+
+// Disabling prefer-default-export in case we want to export more status codes later on.
+// eslint-disable-next-line import/prefer-default-export
+export { HASH_NOT_FOUND };

--- a/library/tests/HTTPStatusCodes.js
+++ b/library/tests/HTTPStatusCodes.js
@@ -1,0 +1,3 @@
+export default {
+  hashNotFound: 303,
+};

--- a/library/tests/fetch.test.js
+++ b/library/tests/fetch.test.js
@@ -7,7 +7,7 @@ import {
   requestOptions,
   serverResponse200,
   serverResponse304,
-} from './mockReqRes.test';
+} from './mockReqRes';
 import {
   getFetchRequestProfile,
   mockServer_HashNotFound,
@@ -15,11 +15,13 @@ import {
   mockServer_NotModified,
   mockErrorGET,
   mockErrorPOST,
-} from './mockFunctions.test';
+} from './mockFunctions';
+
+import { HASH_NOT_FOUND } from './HTTPStatusCodes';
 
 /**
 * Function signature
-* hacheQL(endpoint, options) // IS THE OPTIONS OBJECT OPTIONAL?
+* hacheQL(endpoint, options)
 
 * This function signature is designed to mimic the fetch API. (In fact, the function uses the fetch API under the hood.)
 * https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters
@@ -72,7 +74,7 @@ describe('hacheQL() - client-side wrapper for fetch()', () => {
       expect(Object.hasOwn(hacheQLFetchRequestProfile, 'body')).toBe(false);
     });
 
-    test('If it receives 800, followup request options should be identical to the passed in request options', async () => {
+    test(`If it receives ${HASH_NOT_FOUND}, followup request options should be identical to the passed in request options`, async () => {
       global.fetch = mockServer_HashNotFound;
       await hacheQL(endpointURL, { ...requestOptions, method: 'DELETE' });
       expect(mockServer_HashNotFound.mock.calls.length).toBe(2);
@@ -85,7 +87,7 @@ describe('hacheQL() - client-side wrapper for fetch()', () => {
       jest.clearAllMocks();
     });
 
-    test('Should make a followup request if the initial GET request receives an 800 response.', async () => {
+    test(`Should make a followup request if the initial GET request receives a ${HASH_NOT_FOUND} response.`, async () => {
       expect.assertions(2);
       global.fetch = mockServer_HashNotFound;
       const response = await hacheQL(endpointURL, requestOptions);

--- a/library/tests/middleware.test.js
+++ b/library/tests/middleware.test.js
@@ -3,9 +3,7 @@ import {
 } from '@jest/globals';
 import httpMocks from 'node-mocks-http';
 import { expressHacheQL, nodeHacheQL } from '../hacheql-server';
-import httpCodes from './HTTPStatusCodes';
-
-const HASH_NOT_FOUND = httpCodes.hashNotFound;
+import { HASH_NOT_FOUND } from './HTTPStatusCodes';
 
 // Function signature;
 // checkHash(request, response, next)

--- a/library/tests/middleware.test.js
+++ b/library/tests/middleware.test.js
@@ -1,6 +1,11 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import {
+  describe, expect, jest, test,
+} from '@jest/globals';
 import httpMocks from 'node-mocks-http';
 import { expressHacheQL, nodeHacheQL } from '../hacheql-server';
+import httpCodes from './HTTPStatusCodes';
+
+const HASH_NOT_FOUND = httpCodes.hashNotFound;
 
 // Function signature;
 // checkHash(request, response, next)
@@ -57,10 +62,10 @@ describe('expressHacheQL - server-side function', () => {
   });
 
   describe('GET', () => {
-    it('Should send an 800 response and prevent the execution of any subsequent pieces of middleware if the requested hash is not present in the server\'s cache', async () => {
+    it(`Should send a ${HASH_NOT_FOUND} response and prevent the execution of any subsequent pieces of middleware if the requested hash is not present in the server's cache`, async () => {
       const configuredMiddleware = expressHacheQL({}, cache);
       configuredMiddleware(req, res, next);
-      expect(res.statusCode).toBe(800);
+      expect(res.statusCode).toBe(HASH_NOT_FOUND);
       expect(next).toBeCalledTimes(0);
     });
 
@@ -151,7 +156,7 @@ describe('expressHacheQL - server-side function', () => {
       expect(next).toBeCalledTimes(2);
     });
 
-    it.skip('If there\'s an error in the Redis cache, it should error 800 and switch to the local cache.', async () => {
+    it.skip(`If there's an error in the Redis cache, it should error ${HASH_NOT_FOUND} and switch to the local cache.`, async () => {
       // This will simulate the Redis client being down.
       const fakeRedisClient = {
         get: jest.fn(() => Promise.reject(new Error('Error occurred while accessing the Redis cache.'))),
@@ -162,8 +167,8 @@ describe('expressHacheQL - server-side function', () => {
       // Simulate our function running as part of a middleware chain.
       await configuredMiddleware(req, res, next);
 
-      // Expect to receive and 800 error here.
-      expect(res.statusCode).toBe(800);
+      // Expect to receive a HASH_NOT_FOUND error here.
+      expect(res.statusCode).toBe(HASH_NOT_FOUND);
 
       // Then send a followup post.
       const followupRequest = httpMocks.createRequest(mockReqFollowupPOST);
@@ -179,28 +184,28 @@ describe('expressHacheQL - server-side function', () => {
       }));
     });
 
-    xit('If the redis cache ever errors, ALL subsequent caching should take place in the local memory (potentially update redis cache when back online)', () => {});
+    it.skip('If the redis cache ever errors, ALL subsequent caching should take place in the local memory (potentially update redis cache when back online)', () => {});
   });
 
-  xdescribe('POST', () => {
+  describe.skip('POST', () => {
     it('For a POST request, if there is a hash, it should add the hash and request body to the server\'s cache and invoke the next piece of middleware', () => {});
     it('If there is no hash, it should invoke the next piece of middleware without storing anything in the cache.', () => {});
 
     it('If there was ever an error reading or writing from the redis cache, the request should instead be stored in the local cache', () => {});
     it('If the redis cache is erroring for the first time, switch to the local cache for the memory-life', () => {});
   });
-  xdescribe('other HTTP methods', () => {
+  describe.skip('other HTTP methods', () => {
     it('If anything other than a POST or GET is found, we should invoke next (should we also log an error?)', () => {});
   });
 });
 
-xdescribe('nodeHacheQL - server-side function', () => {
+describe.skip('nodeHacheQL - server-side function', () => {
   describe('Cache characteristics', () => {
     test('The cache should be a FIFO heap, with the most recently accessed item moving to the top. It should be configurable to a certain size.', () => {});
   });
   describe('GET', () => {
     describe('Caching lifecycle', () => {
-      test('Should send an 800 response if the requested hash is not present in the server\'s cache', () => {});
+      test(`Should send an ${HASH_NOT_FOUND} response if the requested hash is not present in the server's cache`, () => {});
     });
     test(`For a GET request, if the requested hash is present in the cache:
         If on finishing the execution of our function the request method is a:
@@ -208,7 +213,7 @@ xdescribe('nodeHacheQL - server-side function', () => {
           GET: The associated query should be stored as req.query`, () => {});
     describe('Edge cases', () => {
       test('Should pass the request along to the next piece of middleware if there isn\'t a hash on the search params', () => {});
-      test('If there\'s an error in the redis cache, it should error 800 and switch to the local cache.', () => {});
+      test(`If there's an error in the redis cache, it should error ${HASH_NOT_FOUND} and switch to the local cache.`, () => {});
       test('If the redis cache ever errors, ALL subsequent caching should take place in the local memory (potentially update redis cache when back online)', () => {});
     });
   });

--- a/library/tests/mockFunctions.js
+++ b/library/tests/mockFunctions.js
@@ -3,8 +3,8 @@ import { jest } from '@jest/globals';
 import {
   serverResponse200,
   serverResponse304,
-  serverResponse800,
-} from './mockReqRes.test';
+  serverResponseHashNotFound,
+} from './mockReqRes';
 
 // MOCK FUNCTIONS ==============================================
 // These functions are used in the tests in place of the actual fetch API.
@@ -25,7 +25,7 @@ const getFetchRequestProfile = jest.fn((endpoint, { method, headers, body }) => 
 // When receiving a POST request: responds with status code 200 and a body of JSON-formatted data, imitating data from a database.
 const mockServer_HashNotFound = jest.fn((endpoint, options) => {
   if (options.method === 'GET') {
-    return Promise.resolve(serverResponse800);
+    return Promise.resolve(serverResponseHashNotFound);
   }
   if (options.method === 'POST') {
     return Promise.resolve(serverResponse200);
@@ -44,7 +44,7 @@ const mockServer_NotModified = jest.fn(() => Promise.resolve(serverResponse304))
 const mockErrorGET = jest.fn(() => Promise.reject(new Error('Ouch! GET me to a doctor!')));
 const mockErrorPOST = jest.fn((endpoint, options) => {
   if (options.method === 'GET') {
-    return Promise.resolve(serverResponse800);
+    return Promise.resolve(serverResponseHashNotFound);
   }
   if (options.method === 'POST') {
     return Promise.reject(new Error('Yikes! This one\'s going to need a POSTmortem!'));

--- a/library/tests/mockReqRes.js
+++ b/library/tests/mockReqRes.js
@@ -1,3 +1,5 @@
+import { HASH_NOT_FOUND } from './HTTPStatusCodes';
+
 const endpointURL = 'graphql';
 const requestOptions = {
   method: 'POST',
@@ -68,8 +70,8 @@ const serverResponse200 = {
 const serverResponse304 = {
   status: 304,
 };
-const serverResponse800 = {
-  status: 800,
+const serverResponseHashNotFound = {
+  status: HASH_NOT_FOUND,
 };
 
 export {
@@ -77,5 +79,5 @@ export {
   requestOptions,
   serverResponse200,
   serverResponse304,
-  serverResponse800,
+  serverResponseHashNotFound,
 };


### PR DESCRIPTION
Originally we had used HTTP status code 800 to mean "hash not found in cache," but we switched to using status code 303 for that purpose. This pull request updates the test files to reflect that change (and also to make it easier to update the files in the future if we change the status code again).

Specifically, this pull request replaces literal references to HTTP status codes 800 and 303 with a HASH_NOT_FOUND variable, imported from a newly created HTTPStatusCodes module. The HTTPStatusCodes module assigns an HTTP code to a variable, so that if the HTTP status code changes again in the future we only need to update the definition in the HTTPStatusCodes module instead of manually updating every test file.

NB: The commit messages only mention replacing status code 800, but that's a mistake. All instances of status code 303 are also replaced by the HASH_NOT_FOUND variable.